### PR TITLE
支持泛域名，同时改用官方python image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM daocloud.io/python:2.7
+FROM python:2.7
 WORKDIR /app
 
 #install acme.sh
@@ -6,8 +6,7 @@ RUN apt-get -y update && apt-get install -y cron socat vim
 RUN git clone https://github.com/Neilpang/acme.sh.git && cd ./acme.sh && ./acme.sh --install && cd ..
 
 #install qiniu sdk
-#TODO if qiniu merge PR,change this to qiniu : https://github.com/qiniu/python-sdk.git
-RUN git clone https://github.com/daozzg/qiniu-python-sdk.git qiniu-python-sdk && cd qiniu-python-sdk && python setup.py install && cd ..
+RUN git clone https://github.com/qiniu/python-sdk.git qiniu-python-sdk && cd qiniu-python-sdk && python setup.py install && cd ..
 
 ADD . /app
 CMD ["bash","startup.sh"]

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -18,7 +18,8 @@
 - Ali_Key: 
 - Ali_Secret: 
 
-##运行
+## 运行
+
 ### 自己构建
 ```
 git clone https://github.com/daozzg/qiniu-cdn-ssl-autoupdate.git
@@ -53,6 +54,10 @@ qiniu-cdn-ssl-autoupdate:
 ```
 docker-compose up -d
 ```
+
+### 泛域名wildcard
+
+指定`DOMAIN=*.wildcard.example.com`即可
 
 ## 代码许可
 

--- a/update_cdn_sslcert.py
+++ b/update_cdn_sslcert.py
@@ -28,5 +28,7 @@ ret, info = domain_manager.create_sslcert("{}/{}".format(domain_name, time.strft
                                           domain_name, privatekey_str, ca_str)
 print(ret['certID'])
 
+if domain_name.startswith("*"):
+    domain_name = domain_name[1:]
 ret, info = domain_manager.put_httpsconf(domain_name, ret['certID'], False)
 print(info)


### PR DESCRIPTION
支持*.wildcard.example.com泛域名。
改用官方image，因为我认为作为（像我一样多疑的）使用者，只有一切从官方出发加开源的代码，才能让人放心地直接使用。